### PR TITLE
TRPC - set max duration limit

### DIFF
--- a/src/app/_trpc/client.ts
+++ b/src/app/_trpc/client.ts
@@ -2,4 +2,9 @@ import { createTRPCReact } from '@trpc/react-query'
 
 import { AppRouter } from '@/trpc'
 
+// This function can run for a maximum of 5 seconds
+export const config = {
+	maxDuration: 60,
+}
+
 export const trpc = createTRPCReact<AppRouter>({})


### PR DESCRIPTION
Set max duration of trpc serverless functions to 60 seconds